### PR TITLE
per-path peer endpoints

### DIFF
--- a/mud.h
+++ b/mud.h
@@ -78,7 +78,7 @@ struct mud_bad {
     } decrypt, difftime, keyx;
 };
 
-struct mud *mud_create (struct sockaddr *);
+struct mud *mud_create (struct sockaddr *, int master);
 void        mud_delete (struct mud *);
 
 int mud_update    (struct mud *);
@@ -94,11 +94,9 @@ int mud_get_key (struct mud *, unsigned char *, size_t *);
 int mud_set_aes  (struct mud *);
 int mud_set_conf (struct mud *, struct mud_conf *);
 
-int mud_set_state (struct mud *, struct sockaddr *, enum mud_state,
-                   unsigned long, unsigned long, unsigned long,
-                   unsigned char, unsigned char);
-
-int mud_peer (struct mud *, struct sockaddr *);
+int mud_set_state (struct mud *, struct sockaddr *, struct sockaddr *,
+                   enum mud_state, unsigned long, unsigned long,
+                   unsigned long, unsigned char, unsigned char);
 
 int mud_recv (struct mud *, void *, size_t);
 int mud_send (struct mud *, const void *, size_t);


### PR DESCRIPTION
This commit allows setting a different peer endpoint per path. So instead of specifying the peer endpoint when creating the tunnel, the user has to instead specify an endpoint when creating a path.

Because the endpoint is no longer being specified when creating a tunnel, there needs to be way to tell mud which role to play. That's what the `master` argument in `mud_create()` is for. Master is the side which controls the paths, slave is the side that learns the available paths from master.